### PR TITLE
Add restore info screen for singleplayer

### DIFF
--- a/common/src/main/resources/assets/x-backup/lang/en_us.json
+++ b/common/src/main/resources/assets/x-backup/lang/en_us.json
@@ -48,5 +48,9 @@
   "xb.gui.backups.restore_check_failed": "This backup is corrupted, cannot restore it!",
   "xb.gui.backups.restored": "Backup restored successfully!",
   "xb.gui.backups.title": "World Backups",
-  "xb.gui.no_polylib": "PolyLib is not installed, please install it to use the GUI."
+  "xb.gui.no_polylib": "PolyLib is not installed, please install it to use the GUI.",
+  "xb.gui.restore.title": "Restore Completed",
+  "xb.gui.restore.id": "Backup #%s",
+  "xb.gui.restore.comment": "Comment: %s",
+  "xb.gui.restore.close": "Back to Title"
 }

--- a/common/src/main/resources/assets/x-backup/lang/zh_cn.json
+++ b/common/src/main/resources/assets/x-backup/lang/zh_cn.json
@@ -48,5 +48,9 @@
   "xb.gui.backups.restore_check_failed": "此备份已损坏，无法回档！",
   "xb.gui.backups.restored": "成功还原备份",
   "xb.gui.backups.title": "备份列表",
-  "xb.gui.no_polylib": "未安装 PolyLib，请安装后使用 GUI 功能。"
+  "xb.gui.no_polylib": "未安装 PolyLib，请安装后使用 GUI 功能。",
+  "xb.gui.restore.title": "回档完成",
+  "xb.gui.restore.id": "备份 #%s",
+  "xb.gui.restore.comment": "备注: %s",
+  "xb.gui.restore.close": "返回标题界面"
 }

--- a/src/main/kotlin/com/github/zly2006/xbackup/Commands.kt
+++ b/src/main/kotlin/com/github/zly2006/xbackup/Commands.kt
@@ -6,6 +6,7 @@ import com.github.zly2006.xbackup.Utils.save
 import com.github.zly2006.xbackup.Utils.send
 import com.github.zly2006.xbackup.Utils.setAutoSaving
 import com.github.zly2006.xbackup.api.IBackup
+import com.github.zly2006.xbackup.gui.RestoreInfoScreen
 import com.github.zly2006.xbackup.ktdsl.register
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.IntegerArgumentType
@@ -739,6 +740,8 @@ object Commands {
                         XBackup.isBusy = false
                         XBackup.restoring = false
                         it.finishRestore()
+                    } else if (!forceStop) {
+                        RestoreInfoScreen.open(backup)
                     }
                 }
             }

--- a/src/main/kotlin/com/github/zly2006/xbackup/gui/RestoreInfoScreen.kt
+++ b/src/main/kotlin/com/github/zly2006/xbackup/gui/RestoreInfoScreen.kt
@@ -1,0 +1,39 @@
+package com.github.zly2006.xbackup.gui
+
+import com.github.zly2006.xbackup.api.IBackup
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.gui.DrawContext
+import net.minecraft.client.gui.screen.Screen
+import net.minecraft.client.gui.widget.ButtonWidget
+import net.minecraft.text.Text
+
+class RestoreInfoScreen(private val backup: IBackup) : Screen(Text.translatable("xb.gui.restore.title")) {
+    override fun init() {
+        addDrawableChild(
+            ButtonWidget.builder(Text.translatable("xb.gui.restore.close")) {
+                client?.setScreen(null)
+            }.dimensions(width / 2 - 75, height - 28, 150, 20).build()
+        )
+    }
+
+    override fun render(context: DrawContext, mouseX: Int, mouseY: Int, delta: Float) {
+        renderBackground(context)
+        context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 20, 0xFFFFFF)
+        var y = height / 2 - 20
+        val idText = Text.translatable("xb.gui.restore.id", backup.id)
+        context.drawCenteredTextWithShadow(textRenderer, idText, width / 2, y, 0xFFFFFF)
+        y += 12
+        if (backup.comment.isNotEmpty()) {
+            val comment = Text.translatable("xb.gui.restore.comment", backup.comment)
+            context.drawCenteredTextWithShadow(textRenderer, comment, width / 2, y, 0xFFFFFF)
+        }
+        super.render(context, mouseX, mouseY, delta)
+    }
+
+    companion object {
+        fun open(backup: IBackup) {
+            val client = MinecraftClient.getInstance()
+            client.execute { client.setScreen(RestoreInfoScreen(backup)) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show a basic screen when restoring in singleplayer
- open the screen from restore command
- update translation files with new entries

## Testing
- `./gradlew test` *(fails: Plugin not found due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_684edf53ee048326881c73d38b28a284