### PR TITLE
Add progress bar and reopen button for restore GUI

### DIFF
--- a/common/src/main/resources/assets/x-backup/lang/en_us.json
+++ b/common/src/main/resources/assets/x-backup/lang/en_us.json
@@ -52,5 +52,6 @@
   "xb.gui.restore.title": "Restore Completed",
   "xb.gui.restore.id": "Backup #%s",
   "xb.gui.restore.comment": "Comment: %s",
-  "xb.gui.restore.close": "Back to Title"
+  "xb.gui.restore.close": "Back to Title",
+  "xb.gui.restore.reopen": "Reopen Save"
 }

--- a/common/src/main/resources/assets/x-backup/lang/zh_cn.json
+++ b/common/src/main/resources/assets/x-backup/lang/zh_cn.json
@@ -52,5 +52,6 @@
   "xb.gui.restore.title": "回档完成",
   "xb.gui.restore.id": "备份 #%s",
   "xb.gui.restore.comment": "备注: %s",
-  "xb.gui.restore.close": "返回标题界面"
+  "xb.gui.restore.close": "返回标题界面",
+  "xb.gui.restore.reopen": "重新打开存档"
 }

--- a/src/main/kotlin/com/github/zly2006/xbackup/Commands.kt
+++ b/src/main/kotlin/com/github/zly2006/xbackup/Commands.kt
@@ -741,7 +741,7 @@ object Commands {
                         XBackup.restoring = false
                         it.finishRestore()
                     } else if (!forceStop) {
-                        RestoreInfoScreen.open(backup)
+                        RestoreInfoScreen.open(backup, path)
                     }
                 }
             }

--- a/src/main/kotlin/com/github/zly2006/xbackup/gui/RestoreInfoScreen.kt
+++ b/src/main/kotlin/com/github/zly2006/xbackup/gui/RestoreInfoScreen.kt
@@ -1,14 +1,23 @@
 package com.github.zly2006.xbackup.gui
 
+import com.github.zly2006.xbackup.XBackup
 import com.github.zly2006.xbackup.api.IBackup
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.widget.ButtonWidget
 import net.minecraft.text.Text
+import java.nio.file.Path
 
-class RestoreInfoScreen(private val backup: IBackup) : Screen(Text.translatable("xb.gui.restore.title")) {
+class RestoreInfoScreen(private val backup: IBackup, private val worldRoot: Path) : Screen(Text.translatable("xb.gui.restore.title")) {
+    private lateinit var reopenButton: ButtonWidget
+
     override fun init() {
+        reopenButton = addDrawableChild(
+            ButtonWidget.builder(Text.translatable("xb.gui.restore.reopen")) {
+                reopenWorld()
+            }.dimensions(width / 2 - 75, height - 52, 150, 20).build()
+        )
         addDrawableChild(
             ButtonWidget.builder(Text.translatable("xb.gui.restore.close")) {
                 client?.setScreen(null)
@@ -28,12 +37,35 @@ class RestoreInfoScreen(private val backup: IBackup) : Screen(Text.translatable(
             val comment = Text.translatable("xb.gui.restore.comment", backup.comment)
             context.drawCenteredTextWithShadow(textRenderer, comment, width / 2, y, 0xFFFFFF)
         }
+
+        val progress = XBackup.service.activeTaskProgress
+        if (progress in 0..100) {
+            val barWidth = 150
+            val barHeight = 8
+            val x = (width - barWidth) / 2
+            val yBar = height / 2 + 20
+            context.fill(x, yBar, x + barWidth, yBar + barHeight, 0xFF555555.toInt())
+            val w = (barWidth * progress) / 100
+            if (w > 0) {
+                context.fill(x + 1, yBar + 1, x + w - 1, yBar + barHeight - 1, 0xFF00FF00.toInt())
+            }
+            context.drawCenteredTextWithShadow(textRenderer, Text.literal("$progress%"), width / 2, yBar - 10, 0xFFFFFF)
+        }
     }
 
     companion object {
-        fun open(backup: IBackup) {
+        fun open(backup: IBackup, worldRoot: Path) {
             val client = MinecraftClient.getInstance()
-            client.execute { client.setScreen(RestoreInfoScreen(backup)) }
+            client.execute { client.setScreen(RestoreInfoScreen(backup, worldRoot)) }
         }
+    }
+
+    private fun reopenWorld() {
+        val client = MinecraftClient.getInstance()
+        client.setScreen(null)
+        runCatching {
+            val loader = client.createIntegratedServerLoader()
+            loader.start(worldRoot)
+        }.onFailure { XBackup.log.error("Failed to reopen world", it) }
     }
 }


### PR DESCRIPTION
## Summary
- show backup restore progress percentage in `RestoreInfoScreen`
- allow re-opening the restored world directly from the GUI
- add translations for the new button

## Testing
- `./gradlew test` *(fails: Plugin [id: 'fabric-loom'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee541692083268b292eb528ea5d80