### PR TITLE
Add 1.20.1 gui compatibility

### DIFF
--- a/src/main/kotlin/com/github/zly2006/xbackup/gui/RestoreInfoScreen.kt
+++ b/src/main/kotlin/com/github/zly2006/xbackup/gui/RestoreInfoScreen.kt
@@ -27,7 +27,11 @@ class RestoreInfoScreen(private val backup: IBackup, private val worldRoot: Path
     }
 
     override fun render(context: DrawContext, mouseX: Int, mouseY: Int, delta: Float) {
+        //? if >=1.20.4 {
         renderBackground(context, mouseX, mouseY, delta)
+        //?} else {
+        /*renderBackground(context)*/
+        *///?}
         super.render(context, mouseX, mouseY, delta)
         context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 20, 0xFFFFFF)
         var y = height / 2 - 20
@@ -66,9 +70,13 @@ class RestoreInfoScreen(private val backup: IBackup, private val worldRoot: Path
         client.setScreen(null)
         runCatching {
             val loader = client.createIntegratedServerLoader()
+            //? if >=1.20.4 {
             loader.start(worldRoot.normalize().name) {
                 this.close()
             }
+            //?} else {
+            /*loader.start(this, worldRoot.normalize().name)*/
+            *///?}
         }.onFailure { XBackup.log.error("Failed to reopen world", it) }
     }
 }


### PR DESCRIPTION
## Summary
- fix RestoreInfoScreen render for old versions
- handle integrated server loading for 1.20.1

## Testing
- `./gradlew chiseledBuild` *(fails: Plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684eedd5112c83269c1f6511aac8bf6a